### PR TITLE
Avoid some of the warnings from using this framework in an app extension.

### DIFF
--- a/DCKeychainItemWrapper.xcodeproj/project.pbxproj
+++ b/DCKeychainItemWrapper.xcodeproj/project.pbxproj
@@ -237,6 +237,7 @@
 		3A8572B91CBFE0A1005FAA7E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -253,6 +254,7 @@
 		3A8572BA1CBFE0A1005FAA7E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -285,6 +287,7 @@
 				3A8572BA1CBFE0A1005FAA7E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/DCKeychainItemWrapper/DCKeychainItemWrapper.h
+++ b/DCKeychainItemWrapper/DCKeychainItemWrapper.h
@@ -26,7 +26,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 /*
  The KeychainItemWrapper class is an abstraction layer for the iPhone Keychain communication. It is merely a

--- a/DCKeychainItemWrapper/KeychainItemWrapper.h
+++ b/DCKeychainItemWrapper/KeychainItemWrapper.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Drew Conner. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 //! Project version number for DCKeychainItemWrapper.
 FOUNDATION_EXPORT double DCKeychainItemWrapperVersionNumber;


### PR DESCRIPTION
Set 'allow app extension API only' flag in project and use platform agnostic Foundation vs UIKit
